### PR TITLE
Add standalone editor window as separate process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,6 +1069,7 @@ dependencies = [
  "regex",
  "rust-embed",
  "serde",
+ "serde_json",
  "serial_test",
  "sqlx",
  "thiserror 2.0.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,6 +1061,7 @@ dependencies = [
  "i18n-embed-fl",
  "include_dir",
  "itertools",
+ "libc",
  "libcosmic",
  "mime 0.3.17",
  "nucleo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ itertools = "0.14"
 regex = "1"
 open = "5"
 serde_json = "1"
+libc = "0.2"
 zbus = { version = "5", default-features = false, features = ["tokio"] }
 
 [dependencies.libcosmic]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ include_dir = "0.7"
 itertools = "0.14"
 regex = "1"
 open = "5"
+serde_json = "1"
 zbus = { version = "5", default-features = false, features = ["tokio"] }
 
 [dependencies.libcosmic]

--- a/i18n/en/cosmic_ext_applet_clipboard_manager.ftl
+++ b/i18n/en/cosmic_ext_applet_clipboard_manager.ftl
@@ -12,8 +12,6 @@ unique_session = Unique session
 unknown_mime_types_title = Mime types
 
 edit-entry = Edit
-save = Save
-cancel = Cancel
 
 data_control = Dummy
     .title = You need to activate the data control Wayland protocol on your device

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,7 +11,6 @@ use cosmic::iced_futures::Subscription;
 use cosmic::iced_runtime::core::window;
 use cosmic::iced_runtime::platform_specific::wayland::layer_surface::SctkLayerSurfaceSettings;
 use cosmic::iced_widget::qr_code;
-use cosmic::iced_widget::text_editor;
 use cosmic::iced_widget::scrollable::RelativeOffset;
 use cosmic::iced_winit::commands::layer_surface::{
     self, KeyboardInteractivity, destroy_layer_surface, get_layer_surface,
@@ -27,6 +26,7 @@ use regex::Regex;
 use crate::clipboard::ClipboardError;
 use crate::config::{Config, PRIVATE_MODE};
 use crate::db::{Content, DbMessage, DbTrait, EntryId, EntryTrait, MimeDataMap};
+use crate::editor_ipc::{self, EditorToApp};
 use crate::message::{AppMsg, ConfigMsg, ContextMenuMsg};
 use crate::navigation::EventMsg;
 use crate::utils::task_message;
@@ -34,7 +34,8 @@ use crate::view::SCROLLABLE_ID;
 use crate::{clipboard, clipboard_watcher, config, ipc, navigation};
 
 use cosmic::{cosmic_config, iced_runtime};
-use std::sync::atomic::{self};
+use std::sync::atomic::{self, AtomicU64};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 pub const QUALIFIER: &str = "io.github";
@@ -47,10 +48,16 @@ pub const APPID: &str = constcat::concat!(QUALIFIER, ".", ORG, ".", APP);
 /// not be restored when the source application clears it.
 const PASSWORD_MANAGER_HINT_MIME: &str = "x-kde-passwordManagerHint";
 
-pub struct EditorState {
+static EDITOR_SESSION_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Tracks the editor subprocess spawned by the applet.
+pub struct EditorProcess {
     pub entry_id: EntryId,
-    pub content: text_editor::Content,
     pub mime: String,
+    pub stdin_handle: std::process::ChildStdin,
+    pub child: std::process::Child,
+    pub stdout_rx: Arc<Mutex<Option<tokio::sync::mpsc::Receiver<EditorToApp>>>>,
+    pub session_id: u64,
 }
 
 pub struct AppState<Db: DbTrait> {
@@ -68,7 +75,7 @@ pub struct AppState<Db: DbTrait> {
     /// Tracks whether the last clipboard entry was sensitive (e.g. from a password manager).
     /// When true, the clipboard will not be restored on clear.
     last_entry_sensitive: bool,
-    pub editor: Option<EditorState>,
+    pub editor: Option<EditorProcess>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -197,12 +204,9 @@ impl<Db: DbTrait> AppState<Db> {
     fn close_popup(&mut self) -> Task<AppMsg> {
         self.focused = 0;
         self.page = 0;
-        self.editor.take();
         self.db.set_query_and_search("".into());
 
         if let Some(popup) = self.popup.take() {
-            // info!("destroy {:?}", popup.id);
-
             self.last_quit = Some((Utc::now().timestamp_millis(), popup.kind));
 
             if popup.is_layer_surface {
@@ -293,6 +297,101 @@ impl<Db: DbTrait> AppState<Db> {
 
                 get_popup(popup_settings)
             }
+        }
+    }
+
+    /// Spawn the editor as a separate process with piped stdin/stdout.
+    fn open_editor_process(
+        &mut self,
+        entry_id: EntryId,
+        text: &str,
+        mime: String,
+    ) -> Task<AppMsg> {
+        // Close existing editor if open
+        if let Some(mut old_editor) = self.editor.take() {
+            let _ = editor_ipc::write_frame(
+                &mut old_editor.stdin_handle,
+                &editor_ipc::AppToEditor::CloseRequested,
+            );
+            // Reap in background to avoid zombies
+            std::thread::spawn(move || {
+                let _ = old_editor.child.wait();
+            });
+        }
+
+        let exe = std::env::current_exe()
+            .unwrap_or_else(|_| "cosmic-ext-applet-clipboard-manager".into());
+
+        let mut child = match std::process::Command::new(&exe)
+            .arg("--editor-window")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::inherit())
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(e) => {
+                error!("failed to spawn editor: {e}");
+                return Task::none();
+            }
+        };
+
+        let mut stdin_handle = child.stdin.take().unwrap();
+        let stdout_handle = child.stdout.take().unwrap();
+
+        // Send Init message
+        if let Err(e) = editor_ipc::write_frame(
+            &mut stdin_handle,
+            &editor_ipc::AppToEditor::Init {
+                entry_id,
+                mime: mime.clone(),
+                content: text.to_string(),
+            },
+        ) {
+            error!("failed to send Init to editor: {e}");
+            return Task::none();
+        }
+
+        // Spawn reader thread for child's stdout
+        let (tx, rx) = tokio::sync::mpsc::channel::<EditorToApp>(8);
+        std::thread::spawn(move || {
+            let mut reader = stdout_handle;
+            loop {
+                match editor_ipc::read_frame::<EditorToApp>(&mut reader) {
+                    Ok(msg) => {
+                        if tx.blocking_send(msg).is_err() {
+                            break;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        let session_id = EDITOR_SESSION_COUNTER.fetch_add(1, atomic::Ordering::Relaxed);
+
+        self.editor = Some(EditorProcess {
+            entry_id,
+            mime,
+            stdin_handle,
+            child,
+            stdout_rx: Arc::new(Mutex::new(Some(rx))),
+            session_id,
+        });
+
+        Task::none()
+    }
+
+    /// Send a message to the editor process. Returns false if send failed.
+    fn send_to_editor(&mut self, msg: &editor_ipc::AppToEditor) -> bool {
+        if let Some(editor) = &mut self.editor {
+            if editor_ipc::write_frame(&mut editor.stdin_handle, msg).is_err() {
+                warn!("failed to send to editor (pipe broken)");
+                return false;
+            }
+            true
+        } else {
+            false
         }
     }
 }
@@ -470,14 +569,6 @@ impl<Db: DbTrait + 'static> cosmic::Application for AppState<Db> {
                 self.clipboard_state = ClipboardState::Init;
             }
             AppMsg::Navigation(message) => {
-                // When editor is open, intercept Escape to cancel editor,
-                // and ignore all other nav keys (let TextEditor handle them)
-                if self.editor.is_some() {
-                    if let EventMsg::Event(Named::Escape) = &message {
-                        self.editor.take();
-                    }
-                    return Task::none();
-                }
                 match message {
                 EventMsg::Event(e) => {
                     let message = match e {
@@ -526,7 +617,6 @@ impl<Db: DbTrait + 'static> cosmic::Application for AppState<Db> {
             }
             AppMsg::ReturnToClipboard => {
                 self.qr_code.take();
-                self.editor.take();
             }
             AppMsg::Config(msg) => match msg {
                 ConfigMsg::PrivateMode(private_mode) => {
@@ -562,16 +652,17 @@ impl<Db: DbTrait + 'static> cosmic::Application for AppState<Db> {
                     }
                 }
                 ContextMenuMsg::Edit(id) => {
-                    if let Some(entry) = self.db.get_from_id(id) {
+                    let edit_info = self.db.get_from_id(id).and_then(|entry| {
                         if let Some(((mime, _), Content::Text(text))) =
                             entry.preferred_content(&self.preferred_mime_types_regex)
                         {
-                            self.editor = Some(EditorState {
-                                entry_id: id,
-                                content: text_editor::Content::with_text(text),
-                                mime: mime.to_string(),
-                            });
+                            Some((text.to_string(), mime.to_string()))
+                        } else {
+                            None
                         }
+                    });
+                    if let Some((text, mime)) = edit_info {
+                        return self.open_editor_process(id, &text, mime);
                     }
                 }
                 ContextMenuMsg::ShowQrCode(id) => {
@@ -601,6 +692,14 @@ impl<Db: DbTrait + 'static> cosmic::Application for AppState<Db> {
                     }
                 }
                 ContextMenuMsg::Delete(id) => {
+                    // If editing this entry, tell editor to close without saving
+                    if self
+                        .editor
+                        .as_ref()
+                        .is_some_and(|e| e.entry_id == id)
+                    {
+                        self.send_to_editor(&editor_ipc::AppToEditor::EntryDeleted);
+                    }
                     if let Err(e) = block_on(self.db.delete(id)) {
                         error!("can't delete {}: {}", id, e);
                     }
@@ -612,20 +711,66 @@ impl<Db: DbTrait + 'static> cosmic::Application for AppState<Db> {
                     error!("{e}");
                 }
             }
-            AppMsg::EditorAction(action) => {
-                if let Some(editor) = &mut self.editor {
-                    editor.content.perform(action);
+            AppMsg::EditLatest => {
+                self.last_quit = None;
+                // Find the most recent text entry and open editor process
+                let edit_info = self
+                    .db
+                    .iter()
+                    .find(|e| {
+                        matches!(
+                            e.preferred_content(&self.preferred_mime_types_regex),
+                            Some((_, Content::Text(_)))
+                        )
+                    })
+                    .and_then(|entry| {
+                        if let Some(((mime, _), Content::Text(text))) =
+                            entry.preferred_content(&self.preferred_mime_types_regex)
+                        {
+                            Some((entry.id(), text.to_string(), mime.to_string()))
+                        } else {
+                            None
+                        }
+                    });
+                if let Some((id, text, mime)) = edit_info {
+                    return self.open_editor_process(id, &text, mime);
                 }
             }
-            AppMsg::EditorSave => {
-                if let Some(editor) = self.editor.take() {
-                    let text = editor.content.text();
+            AppMsg::EditorEvent(msg) => match msg {
+                EditorToApp::Ready => {}
+                EditorToApp::SaveDraft {
+                    entry_id,
+                    content,
+                } => {
+                    let mime = self
+                        .editor
+                        .as_ref()
+                        .map(|e| e.mime.clone())
+                        .unwrap_or_else(|| "text/plain".to_string());
                     let mut data = MimeDataMap::new();
-                    data.insert(editor.mime.clone(), text.as_bytes().to_vec());
-                    if editor.mime != "text/plain" {
-                        data.insert("text/plain".to_string(), text.as_bytes().to_vec());
+                    data.insert(mime.clone(), content.as_bytes().to_vec());
+                    if mime != "text/plain" {
+                        data.insert("text/plain".to_string(), content.as_bytes().to_vec());
                     }
-                    match block_on(self.db.update_content(editor.entry_id, data.clone())) {
+                    if let Err(e) = block_on(self.db.update_content(entry_id, data)) {
+                        error!("failed to save draft: {e}");
+                    }
+                }
+                EditorToApp::SaveFinal {
+                    entry_id,
+                    content,
+                } => {
+                    let mime = self
+                        .editor
+                        .as_ref()
+                        .map(|e| e.mime.clone())
+                        .unwrap_or_else(|| "text/plain".to_string());
+                    let mut data = MimeDataMap::new();
+                    data.insert(mime.clone(), content.as_bytes().to_vec());
+                    if mime != "text/plain" {
+                        data.insert("text/plain".to_string(), content.as_bytes().to_vec());
+                    }
+                    match block_on(self.db.update_content(entry_id, data.clone())) {
                         Ok(id) => {
                             let clip_data = self
                                 .db
@@ -634,35 +779,15 @@ impl<Db: DbTrait + 'static> cosmic::Application for AppState<Db> {
                                 .unwrap_or(data);
                             return copy_iced(clip_data);
                         }
-                        Err(e) => error!("failed to update entry: {e}"),
+                        Err(e) => error!("failed to save final: {e}"),
                     }
                 }
-            }
-            AppMsg::EditorCancel => {
-                self.editor.take();
-            }
-            AppMsg::EditLatest => {
-                self.last_quit = None;
-                // Find the most recent text entry and open it in editor
-                let text_entry = self.db.iter().find(|e| {
-                    matches!(
-                        e.preferred_content(&self.preferred_mime_types_regex),
-                        Some((_, Content::Text(_)))
-                    )
-                });
-                if let Some(entry) = text_entry {
-                    if let Some(((mime, _), Content::Text(text))) =
-                        entry.preferred_content(&self.preferred_mime_types_regex)
-                    {
-                        let id = entry.id();
-                        self.editor = Some(EditorState {
-                            entry_id: id,
-                            content: text_editor::Content::with_text(text),
-                            mime: mime.to_string(),
-                        });
-                    }
+                EditorToApp::Closed => {}
+            },
+            AppMsg::EditorProcessExited => {
+                if let Some(mut editor) = self.editor.take() {
+                    let _ = editor.child.wait();
                 }
-                return self.toggle_popup_ext(PopupKind::Popup, true);
             }
         }
         Task::none()
@@ -704,6 +829,34 @@ impl<Db: DbTrait + 'static> cosmic::Application for AppState<Db> {
             ipc::dbus_toggle_subscription(),
         ];
 
+        // Editor process IPC subscription
+        if let Some(editor) = &self.editor {
+            let rx_arc = editor.stdout_rx.clone();
+            let session_id = editor.session_id;
+            subscriptions.push(Subscription::run_with_id(
+                session_id,
+                cosmic::iced::stream::channel(8, move |mut output| async move {
+                    use cosmic::iced::futures::SinkExt;
+                    let rx_opt = rx_arc.lock().unwrap().take();
+                    let Some(mut rx) = rx_opt else {
+                        futures::future::pending::<()>().await;
+                        unreachable!();
+                    };
+                    loop {
+                        match rx.recv().await {
+                            Some(msg) => {
+                                output.send(AppMsg::EditorEvent(msg)).await.ok();
+                            }
+                            None => {
+                                output.send(AppMsg::EditorProcessExited).await.ok();
+                                futures::future::pending::<()>().await;
+                            }
+                        }
+                    }
+                }),
+            ));
+        }
+
         if !self.clipboard_state.is_error() {
             subscriptions.push(Subscription::run(|| {
                 clipboard::sub().map(AppMsg::ClipboardEvent)
@@ -714,6 +867,15 @@ impl<Db: DbTrait + 'static> cosmic::Application for AppState<Db> {
     }
 
     fn on_app_exit(&mut self) -> Option<Self::Message> {
+        // Tell editor to close gracefully before applet exits
+        if let Some(mut editor) = self.editor.take() {
+            let _ = editor_ipc::write_frame(
+                &mut editor.stdin_handle,
+                &editor_ipc::AppToEditor::CloseRequested,
+            );
+            let _ = editor.child.wait();
+        }
+
         if self.config.unique_session
             && let Err(err) = block_on(self.db.clear())
         {

--- a/src/app.rs
+++ b/src/app.rs
@@ -355,17 +355,23 @@ impl<Db: DbTrait> AppState<Db> {
         // Spawn reader thread for child's stdout
         let (tx, rx) = tokio::sync::mpsc::channel::<EditorToApp>(8);
         std::thread::spawn(move || {
-            let mut reader = stdout_handle;
+            let mut reader = std::io::BufReader::new(stdout_handle);
             loop {
                 match editor_ipc::read_frame::<EditorToApp>(&mut reader) {
                     Ok(msg) => {
+                        eprintln!("[applet-reader] Read frame: {msg:?}");
                         if tx.blocking_send(msg).is_err() {
+                            eprintln!("[applet-reader] mpsc send failed, breaking");
                             break;
                         }
                     }
-                    Err(_) => break,
+                    Err(e) => {
+                        eprintln!("[applet-reader] read_frame error: {e}");
+                        break;
+                    }
                 }
             }
+            eprintln!("[applet-reader] Reader thread exiting");
         });
 
         let session_id = EDITOR_SESSION_COUNTER.fetch_add(1, atomic::Ordering::Relaxed);
@@ -736,55 +742,64 @@ impl<Db: DbTrait + 'static> cosmic::Application for AppState<Db> {
                     return self.open_editor_process(id, &text, mime);
                 }
             }
-            AppMsg::EditorEvent(msg) => match msg {
-                EditorToApp::Ready => {}
-                EditorToApp::SaveDraft {
-                    entry_id,
-                    content,
-                } => {
-                    let mime = self
-                        .editor
-                        .as_ref()
-                        .map(|e| e.mime.clone())
-                        .unwrap_or_else(|| "text/plain".to_string());
-                    let mut data = MimeDataMap::new();
-                    data.insert(mime.clone(), content.as_bytes().to_vec());
-                    if mime != "text/plain" {
-                        data.insert("text/plain".to_string(), content.as_bytes().to_vec());
-                    }
-                    if let Err(e) = block_on(self.db.update_content(entry_id, data)) {
-                        error!("failed to save draft: {e}");
-                    }
-                }
-                EditorToApp::SaveFinal {
-                    entry_id,
-                    content,
-                } => {
-                    let mime = self
-                        .editor
-                        .as_ref()
-                        .map(|e| e.mime.clone())
-                        .unwrap_or_else(|| "text/plain".to_string());
-                    let mut data = MimeDataMap::new();
-                    data.insert(mime.clone(), content.as_bytes().to_vec());
-                    if mime != "text/plain" {
-                        data.insert("text/plain".to_string(), content.as_bytes().to_vec());
-                    }
-                    match block_on(self.db.update_content(entry_id, data.clone())) {
-                        Ok(id) => {
-                            let clip_data = self
-                                .db
-                                .get_from_id(id)
-                                .map(|e| e.raw_content().clone())
-                                .unwrap_or(data);
-                            return copy_iced(clip_data);
+            AppMsg::EditorEvent(msg) => {
+                eprintln!("[applet] EditorEvent: {msg:?}");
+                match msg {
+                    EditorToApp::Ready => {}
+                    EditorToApp::SaveDraft {
+                        entry_id,
+                        content,
+                    } => {
+                        eprintln!("[applet] SaveDraft entry_id={entry_id}, content_len={}", content.len());
+                        let mime = self
+                            .editor
+                            .as_ref()
+                            .map(|e| e.mime.clone())
+                            .unwrap_or_else(|| "text/plain".to_string());
+                        let mut data = MimeDataMap::new();
+                        data.insert(mime.clone(), content.as_bytes().to_vec());
+                        if mime != "text/plain" {
+                            data.insert("text/plain".to_string(), content.as_bytes().to_vec());
                         }
-                        Err(e) => error!("failed to save final: {e}"),
+                        if let Err(e) = block_on(self.db.update_content(entry_id, data)) {
+                            error!("failed to save draft: {e}");
+                        }
+                    }
+                    EditorToApp::SaveFinal {
+                        entry_id,
+                        content,
+                    } => {
+                        eprintln!("[applet] SaveFinal entry_id={entry_id}, content_len={}", content.len());
+                        let mime = self
+                            .editor
+                            .as_ref()
+                            .map(|e| e.mime.clone())
+                            .unwrap_or_else(|| "text/plain".to_string());
+                        let mut data = MimeDataMap::new();
+                        data.insert(mime.clone(), content.as_bytes().to_vec());
+                        if mime != "text/plain" {
+                            data.insert("text/plain".to_string(), content.as_bytes().to_vec());
+                        }
+                        match block_on(self.db.update_content(entry_id, data.clone())) {
+                            Ok(id) => {
+                                eprintln!("[applet] SaveFinal: DB update OK, new id={id}");
+                                let clip_data = self
+                                    .db
+                                    .get_from_id(id)
+                                    .map(|e| e.raw_content().clone())
+                                    .unwrap_or(data);
+                                return copy_iced(clip_data);
+                            }
+                            Err(e) => error!("failed to save final: {e}"),
+                        }
+                    }
+                    EditorToApp::Closed => {
+                        eprintln!("[applet] Editor sent Closed (no changes)");
                     }
                 }
-                EditorToApp::Closed => {}
             },
             AppMsg::EditorProcessExited => {
+                eprintln!("[applet] EditorProcessExited");
                 if let Some(mut editor) = self.editor.take() {
                     let _ = editor.child.wait();
                 }
@@ -845,9 +860,11 @@ impl<Db: DbTrait + 'static> cosmic::Application for AppState<Db> {
                     loop {
                         match rx.recv().await {
                             Some(msg) => {
+                                eprintln!("[applet-sub] Received from editor: {msg:?}");
                                 output.send(AppMsg::EditorEvent(msg)).await.ok();
                             }
                             None => {
+                                eprintln!("[applet-sub] Editor channel closed, sending EditorProcessExited");
                                 output.send(AppMsg::EditorProcessExited).await.ok();
                                 futures::future::pending::<()>().await;
                             }

--- a/src/editor_app.rs
+++ b/src/editor_app.rs
@@ -1,0 +1,231 @@
+//! Standalone COSMIC editor application.
+//! Runs as a separate process, communicates with the applet via stdin/stdout pipes.
+
+use cosmic::app::{Core, Task};
+use cosmic::iced::Length;
+use cosmic::iced_core::text::Wrapping;
+use cosmic::iced_futures::Subscription;
+use cosmic::iced_widget::text_editor;
+use cosmic::widget::container;
+use cosmic::Element;
+
+use crate::editor_ipc::{self, AppToEditor, EditorToApp};
+
+const EDITOR_APP_ID: &str = "io.github.cosmic_utils.clipboard-editor";
+
+#[derive(Debug, Clone)]
+pub enum EditorMsg {
+    EditorAction(text_editor::Action),
+    FocusLost,
+    IpcMessage(AppToEditor),
+    IpcDisconnected,
+    CloseWindow,
+}
+
+pub struct EditorApp {
+    core: Core,
+    entry_id: i64,
+    content: text_editor::Content,
+    original_text: String,
+}
+
+pub struct EditorFlags {
+    pub entry_id: i64,
+    pub mime: String,
+    pub text: String,
+}
+
+impl EditorApp {
+    fn send_to_applet(msg: &EditorToApp) {
+        let stdout = std::io::stdout();
+        let mut lock = stdout.lock();
+        let _ = editor_ipc::write_frame(&mut lock, msg);
+    }
+
+    fn save_and_exit(&mut self) -> ! {
+        let text = self.content.text();
+        let msg = if text.trim() != self.original_text.trim() {
+            EditorToApp::SaveFinal {
+                entry_id: self.entry_id,
+                content: text,
+            }
+        } else {
+            EditorToApp::Closed
+        };
+        Self::send_to_applet(&msg);
+        std::process::exit(0);
+    }
+}
+
+impl cosmic::Application for EditorApp {
+    type Executor = cosmic::executor::Default;
+    type Flags = EditorFlags;
+    type Message = EditorMsg;
+    const APP_ID: &'static str = EDITOR_APP_ID;
+
+    fn core(&self) -> &Core {
+        &self.core
+    }
+
+    fn core_mut(&mut self) -> &mut Core {
+        &mut self.core
+    }
+
+    fn init(mut core: Core, flags: Self::Flags) -> (Self, Task<Self::Message>) {
+        core.window.show_close = false;
+        core.window.show_minimize = false;
+        core.window.show_maximize = false;
+        core.window.header_title = "Edit".into();
+
+        Self::send_to_applet(&EditorToApp::Ready);
+
+        let app = EditorApp {
+            core,
+            entry_id: flags.entry_id,
+            content: text_editor::Content::with_text(&flags.text),
+            original_text: flags.text,
+        };
+        (app, Task::none())
+    }
+
+    fn update(&mut self, message: Self::Message) -> Task<Self::Message> {
+        match message {
+            EditorMsg::EditorAction(action) => {
+                self.content.perform(action);
+            }
+            EditorMsg::FocusLost => {
+                self.save_and_exit();
+            }
+            EditorMsg::CloseWindow => {
+                self.save_and_exit();
+            }
+            EditorMsg::IpcMessage(msg) => match msg {
+                AppToEditor::EntryDeleted | AppToEditor::CloseRequested => {
+                    Self::send_to_applet(&EditorToApp::Closed);
+                    std::process::exit(0);
+                }
+                AppToEditor::Init { .. } => {}
+            },
+            EditorMsg::IpcDisconnected => {
+                self.save_and_exit();
+            }
+        }
+        Task::none()
+    }
+
+    fn view(&self) -> Element<'_, Self::Message> {
+        let editor = cosmic::widget::text_editor(&self.content)
+            .on_action(EditorMsg::EditorAction)
+            .wrapping(Wrapping::Word)
+            .height(Length::Fill)
+            .padding(10);
+
+        container(editor)
+            .padding(10)
+            .height(Length::Fill)
+            .width(Length::Fill)
+            .into()
+    }
+
+    fn subscription(&self) -> Subscription<Self::Message> {
+        use cosmic::iced::stream::channel;
+
+        let focus_sub = cosmic::iced_futures::event::listen_with(|event, _status, _id| {
+            if let cosmic::iced::Event::Window(
+                cosmic::iced_runtime::core::window::Event::Unfocused,
+            ) = event
+            {
+                Some(EditorMsg::FocusLost)
+            } else {
+                None
+            }
+        });
+
+        let ipc_sub = Subscription::run_with_id(
+            "editor_stdin_ipc",
+            channel(8, |mut output| async move {
+                use cosmic::iced::futures::SinkExt;
+                let (tx, mut rx) = tokio::sync::mpsc::channel::<AppToEditor>(8);
+
+                std::thread::spawn(move || {
+                    let stdin = std::io::stdin();
+                    let mut locked = stdin.lock();
+                    loop {
+                        match editor_ipc::read_frame::<AppToEditor>(&mut locked) {
+                            Ok(msg) => {
+                                if tx.blocking_send(msg).is_err() {
+                                    break;
+                                }
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                });
+
+                loop {
+                    match rx.recv().await {
+                        Some(msg) => {
+                            output.send(EditorMsg::IpcMessage(msg)).await.ok();
+                        }
+                        None => {
+                            output.send(EditorMsg::IpcDisconnected).await.ok();
+                            futures::future::pending::<()>().await;
+                        }
+                    }
+                }
+            }),
+        );
+
+        Subscription::batch([focus_sub, ipc_sub])
+    }
+
+    fn on_close_requested(
+        &self,
+        _id: cosmic::iced_runtime::core::window::Id,
+    ) -> Option<Self::Message> {
+        Some(EditorMsg::CloseWindow)
+    }
+}
+
+/// Entry point for the editor process.
+pub fn run_editor() {
+    let init_msg = {
+        let stdin = std::io::stdin();
+        let mut locked = stdin.lock();
+        match editor_ipc::read_frame::<AppToEditor>(&mut locked) {
+            Ok(msg) => msg,
+            Err(e) => {
+                eprintln!("Failed to read Init from stdin: {e}");
+                std::process::exit(1);
+            }
+        }
+    };
+
+    let (entry_id, mime, content) = match init_msg {
+        AppToEditor::Init {
+            entry_id,
+            mime,
+            content,
+        } => (entry_id, mime, content),
+        other => {
+            eprintln!("Expected Init message, got: {other:?}");
+            std::process::exit(1);
+        }
+    };
+
+    let settings = cosmic::app::Settings::default()
+        .size(cosmic::iced::Size::new(600.0, 500.0))
+        .transparent(false)
+        .exit_on_close(false);
+
+    let flags = EditorFlags {
+        entry_id,
+        mime,
+        text: content,
+    };
+
+    if let Err(e) = cosmic::app::run::<EditorApp>(settings, flags) {
+        eprintln!("Editor app failed: {e}");
+        std::process::exit(1);
+    }
+}

--- a/src/editor_app.rs
+++ b/src/editor_app.rs
@@ -1,5 +1,7 @@
 //! Standalone COSMIC editor application.
-//! Runs as a separate process, communicates with the applet via stdin/stdout pipes.
+//! Runs as a separate process, communicates with the applet via pipes.
+//! stdout is redirected to stderr before COSMIC starts (COSMIC writes to stdout),
+//! so IPC uses a dup'd fd saved before the redirect.
 
 use cosmic::app::{Core, Task};
 use cosmic::iced::Length;
@@ -8,8 +10,12 @@ use cosmic::iced_futures::Subscription;
 use cosmic::iced_widget::text_editor;
 use cosmic::widget::container;
 use cosmic::Element;
+use std::sync::OnceLock;
 
 use crate::editor_ipc::{self, AppToEditor, EditorToApp};
+
+/// Holds the original stdout pipe fd (saved before COSMIC redirects stdout).
+static IPC_WRITER: OnceLock<std::sync::Mutex<std::fs::File>> = OnceLock::new();
 
 const EDITOR_APP_ID: &str = "io.github.cosmic_utils.clipboard-editor";
 
@@ -37,14 +43,23 @@ pub struct EditorFlags {
 
 impl EditorApp {
     fn send_to_applet(msg: &EditorToApp) {
-        let stdout = std::io::stdout();
-        let mut lock = stdout.lock();
-        let _ = editor_ipc::write_frame(&mut lock, msg);
+        if let Some(writer) = IPC_WRITER.get() {
+            let mut guard = writer.lock().unwrap();
+            if let Err(e) = editor_ipc::write_frame(&mut *guard, msg) {
+                eprintln!("[editor] Failed to send {msg:?}: {e}");
+            } else {
+                eprintln!("[editor] Sent: {msg:?}");
+            }
+        } else {
+            eprintln!("[editor] IPC_WRITER not initialized, can't send {msg:?}");
+        }
     }
 
     fn save_and_exit(&mut self) -> ! {
         let text = self.content.text();
-        let msg = if text.trim() != self.original_text.trim() {
+        let is_dirty = text.trim() != self.original_text.trim();
+        eprintln!("[editor] save_and_exit: dirty={is_dirty}, text_len={}, original_len={}", text.len(), self.original_text.len());
+        let msg = if is_dirty {
             EditorToApp::SaveFinal {
                 entry_id: self.entry_id,
                 content: text,
@@ -72,10 +87,7 @@ impl cosmic::Application for EditorApp {
     }
 
     fn init(mut core: Core, flags: Self::Flags) -> (Self, Task<Self::Message>) {
-        core.window.show_close = false;
-        core.window.show_minimize = false;
-        core.window.show_maximize = false;
-        core.window.header_title = "Edit".into();
+        core.window.show_headerbar = false;
 
         Self::send_to_applet(&EditorToApp::Ready);
 
@@ -114,14 +126,24 @@ impl cosmic::Application for EditorApp {
     }
 
     fn view(&self) -> Element<'_, Self::Message> {
+        let title = cosmic::widget::text::title3("Clipboard Manager Editor")
+            .width(Length::Fill)
+            .align_x(cosmic::iced::alignment::Horizontal::Center);
+
         let editor = cosmic::widget::text_editor(&self.content)
             .on_action(EditorMsg::EditorAction)
             .wrapping(Wrapping::Word)
             .height(Length::Fill)
             .padding(10);
 
-        container(editor)
-            .padding(10)
+        cosmic::widget::column()
+            .push(container(title).padding([8, 10]))
+            .push(
+                container(editor)
+                    .padding(10)
+                    .height(Length::Fill)
+                    .width(Length::Fill),
+            )
             .height(Length::Fill)
             .width(Length::Fill)
             .into()
@@ -189,6 +211,25 @@ impl cosmic::Application for EditorApp {
 
 /// Entry point for the editor process.
 pub fn run_editor() {
+    use std::os::unix::io::{AsRawFd, FromRawFd};
+
+    // Save the original stdout pipe fd for IPC BEFORE COSMIC app init.
+    // COSMIC/iced writes to stdout during app startup, which would corrupt
+    // our length-prefixed IPC frames. We dup stdout, then redirect fd 1 to stderr.
+    let ipc_fd = unsafe { libc::dup(std::io::stdout().as_raw_fd()) };
+    if ipc_fd < 0 {
+        eprintln!("Failed to dup stdout for IPC");
+        std::process::exit(1);
+    }
+    // Redirect stdout to stderr so COSMIC's writes don't go through the pipe
+    unsafe {
+        libc::dup2(std::io::stderr().as_raw_fd(), std::io::stdout().as_raw_fd());
+    }
+    let ipc_file = unsafe { std::fs::File::from_raw_fd(ipc_fd) };
+    IPC_WRITER
+        .set(std::sync::Mutex::new(ipc_file))
+        .expect("IPC_WRITER already set");
+
     let init_msg = {
         let stdin = std::io::stdin();
         let mut locked = stdin.lock();

--- a/src/editor_ipc.rs
+++ b/src/editor_ipc.rs
@@ -1,0 +1,57 @@
+//! IPC protocol for applet ↔ editor communication via stdin/stdout pipes.
+//! Uses length-prefixed JSON frames for robust message framing.
+
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use std::io::{self, Read, Write};
+
+/// Messages from applet to editor process.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum AppToEditor {
+    /// Initial payload with entry content to edit.
+    Init {
+        entry_id: i64,
+        mime: String,
+        content: String,
+    },
+    /// The entry being edited was deleted — editor should close without saving.
+    EntryDeleted,
+    /// Applet requests editor to close (e.g., re-edit different entry).
+    CloseRequested,
+}
+
+/// Messages from editor process to applet.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum EditorToApp {
+    /// Editor is ready and displaying content.
+    Ready,
+    /// Auto-save on focus loss (keep editor open, don't recopy to clipboard).
+    SaveDraft { entry_id: i64, content: String },
+    /// Final save on close (update DB + copy to clipboard).
+    SaveFinal { entry_id: i64, content: String },
+    /// Editor closed without changes.
+    Closed,
+}
+
+/// Write a length-prefixed JSON frame to the writer.
+pub fn write_frame(writer: &mut impl Write, msg: &impl Serialize) -> io::Result<()> {
+    let json =
+        serde_json::to_vec(msg).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let len = json.len() as u32;
+    writer.write_all(&len.to_be_bytes())?;
+    writer.write_all(&json)?;
+    writer.flush()?;
+    Ok(())
+}
+
+/// Read a length-prefixed JSON frame from the reader.
+pub fn read_frame<T: DeserializeOwned>(reader: &mut impl Read) -> io::Result<T> {
+    let mut len_buf = [0u8; 4];
+    reader.read_exact(&mut len_buf)?;
+    let len = u32::from_be_bytes(len_buf) as usize;
+    if len > 64 * 1024 * 1024 {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "frame too large"));
+    }
+    let mut buf = vec![0u8; len];
+    reader.read_exact(&mut buf)?;
+    serde_json::from_slice(&buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,8 @@ mod clipboard;
 mod clipboard_watcher;
 mod config;
 mod db;
+mod editor_app;
+mod editor_ipc;
 mod icon;
 mod ipc;
 mod localize;
@@ -49,6 +51,13 @@ fn setup_logs() {
 
 fn main() {
     for arg in std::env::args().skip(1) {
+        if arg == "--editor-window" {
+            localize::localize();
+            setup_logs();
+            editor_app::run_editor();
+            return;
+        }
+
         if arg == "-V" || arg == "--version" {
             let version = env!("CARGO_PKG_VERSION");
             let commit = option_env!("CLIPBOARD_MANAGER_COMMIT").unwrap_or("unknown");

--- a/src/message.rs
+++ b/src/message.rs
@@ -2,6 +2,7 @@ use crate::{
     clipboard::ClipboardMessage,
     config::Config,
     db::{DbMessage, EntryId, MimeDataMap},
+    editor_ipc::EditorToApp,
     navigation::EventMsg,
 };
 
@@ -28,9 +29,8 @@ pub enum AppMsg {
     LinkClicked(markdown::Url),
     DbusToggle,
     EditLatest,
-    EditorAction(cosmic::iced_widget::text_editor::Action),
-    EditorSave,
-    EditorCancel,
+    EditorEvent(EditorToApp),
+    EditorProcessExited,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Copy)]

--- a/src/view.rs
+++ b/src/view.rs
@@ -3,7 +3,6 @@ use std::{borrow::Cow, cmp::min, sync::LazyLock};
 use cosmic::{
     Apply, Element,
     iced::{Alignment, Length, alignment::Horizontal, padding},
-    iced_core::text::Wrapping,
     iced_widget::{
         Stack,
         scrollable::{Direction, Scrollbar},
@@ -19,7 +18,7 @@ use cosmic::{
 use itertools::Itertools;
 
 use crate::{
-    app::{AppState, ClipboardState, EditorState, ErrorState},
+    app::{AppState, ClipboardState, ErrorState},
     db::{Content, DbTrait, EntryTrait, MimeDataMap},
     fl, icon, icon_button,
     message::{AppMsg, ConfigMsg, ContextMenuMsg},
@@ -71,8 +70,6 @@ impl<Db: DbTrait> AppState<Db> {
             self.error_view(e)
         } else if let Some(qr_code_res) = &self.qr_code {
             self.qr_code_view(qr_code_res)
-        } else if let Some(editor_state) = &self.editor {
-            self.editor_view(editor_state)
         } else {
             self.list_view()
         })
@@ -87,34 +84,6 @@ impl<Db: DbTrait> AppState<Db> {
             Length::Fixed(400f32)
         })
         .into()
-    }
-    fn editor_view<'a>(&self, state: &'a EditorState) -> Element<'a, AppMsg> {
-        let header = row()
-            .push(
-                button::text(fl!("cancel"))
-                    .on_press(AppMsg::EditorCancel)
-                    .width(Length::Shrink),
-            )
-            .push(horizontal_space())
-            .push(
-                button::suggested(fl!("save"))
-                    .on_press(AppMsg::EditorSave)
-                    .width(Length::Shrink),
-            )
-            .width(Length::Fill);
-
-        let editor = cosmic::widget::text_editor(&state.content)
-            .on_action(AppMsg::EditorAction)
-            .wrapping(Wrapping::Word)
-            .height(Length::Fill)
-            .padding(10);
-
-        column()
-            .push(container(header).padding(padding::all(15f32).bottom(0)))
-            .push(container(editor).padding(padding::all(10).top(5)).height(Length::Fill))
-            .spacing(10)
-            .height(Length::Fill)
-            .into()
     }
 
     pub fn page_count(&self) -> usize {


### PR DESCRIPTION
## Summary

- Replaces the in-popup clipboard entry editor with a **standalone resizable COSMIC window** running as a separate process (`--editor-window` flag)
- Applet and editor communicate via **stdin/stdout pipes using length-prefixed JSON frames** (`editor_ipc.rs`)
- Editor **auto-saves and closes on focus loss** — no explicit save/cancel buttons, no close/minimize/maximize buttons
- Saves changed content back to the DB and copies to clipboard on close

## Architecture

The editor runs as a child process of the applet (same binary, `--editor-window` flag). IPC uses the child's stdin (applet→editor) and a dup'd stdout fd (editor→applet). COSMIC/iced writes to stdout during app initialization, so the editor saves the original stdout pipe fd via `libc::dup()` before redirecting stdout to stderr.

### IPC Protocol
- `AppToEditor`: `Init`, `EntryDeleted`, `CloseRequested`
- `EditorToApp`: `Ready`, `SaveDraft`, `SaveFinal`, `Closed`

## Dependencies / Build Order

> **This PR targets the `integrated-features` branch, NOT `master`.**

This branch is built on top of the following prior work that must be merged first (in order):

| # | Branch | PR | Key Commits |
|---|--------|----|-------------|
| 1 | `fix/memory-leaks` | — | `db146a1` Fix memory leaks: offers HashMap, dead events Vec, runtime eviction |
| 2 | `fix/respect-password-manager-clipboard-clear` | — | `64ffd5d` Respect password manager clipboard clearing |
| 3 | `feat/dbus-toggle` | — | `33bed65` Add D-Bus toggle for keyboard shortcut support |
| 4 | `fix/toggle-shortcut-and-async-clipboard` | — | `5ddf911`→`b5c4b94` Consolidate D-Bus toggle, async clipboard, scroll fixes, pagination fix |

All of the above are consolidated into the **`integrated-features`** branch (`b5c4b94`), which is the base for this PR.

## Files Changed

| File | Change |
|------|--------|
| `src/editor_ipc.rs` | **NEW** — IPC protocol (length-prefixed JSON frames) |
| `src/editor_app.rs` | **NEW** — Standalone COSMIC Application for editor window |
| `src/app.rs` | EditorProcess struct, spawn/reap, IPC subscription, save handlers |
| `src/main.rs` | `--editor-window` flag, module declarations |
| `src/message.rs` | Replace old editor messages with `EditorEvent`/`EditorProcessExited` |
| `src/view.rs` | Remove in-popup editor view |
| `Cargo.toml` | Add `serde_json`, `libc` dependencies |
| `i18n/en/...ftl` | Remove unused `save`/`cancel` keys |

## Test plan

- [ ] Right-click text entry → "Edit" → standalone resizable editor window opens
- [ ] Window shows "Clipboard Manager Editor" title, no close/minimize/maximize buttons
- [ ] Edit text, click away (focus loss) → editor saves changes and closes
- [ ] Open popup again → entry shows updated text
- [ ] Edit without changes, click away → editor closes without unnecessary save
- [ ] `cosmic-ext-applet-clipboard-manager --edit` → editor opens with latest text entry
- [ ] Delete entry while editor is open → editor closes gracefully
- [ ] Edit different entry while editor already open → old editor closes, new one opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)